### PR TITLE
Pin npm dependencies to exact versions (KEW-11036)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    versioning-strategy: increase

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,17 +9,17 @@
       "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
-        "@xmldom/xmldom": "^0.8.10",
-        "lodash": "^4.17.21"
+        "@xmldom/xmldom": "0.8.13",
+        "lodash": "4.18.1"
       },
       "devDependencies": {
-        "@babel/core": "^7.28.5",
-        "@babel/preset-env": "^7.28.5",
-        "babel-loader": "^10.0.0",
-        "webpack": "^5.104.0",
-        "webpack-cli": "^6.0.1",
-        "webpack-fix-default-import-plugin": "^1.0.3",
-        "webpack-node-externals": "^3.0.0"
+        "@babel/core": "7.28.5",
+        "@babel/preset-env": "7.28.5",
+        "babel-loader": "10.0.0",
+        "webpack": "5.105.4",
+        "webpack-cli": "6.0.1",
+        "webpack-fix-default-import-plugin": "1.0.3",
+        "webpack-node-externals": "3.0.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -53,6 +53,7 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -1843,9 +1844,9 @@
       }
     },
     "node_modules/@xmldom/xmldom": {
-      "version": "0.8.12",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.12.tgz",
-      "integrity": "sha512-9k/gHF6n/pAi/9tqr3m3aqkuiNosYTurLLUtc7xQ9sxB/wm7WPygCv8GYa6mS0fLJEHhqMC1ATYhz++U/lRHqg==",
+      "version": "0.8.13",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.13.tgz",
+      "integrity": "sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
@@ -1869,6 +1870,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1894,6 +1896,7 @@
       "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -2090,6 +2093,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -3170,6 +3174,7 @@
       "integrity": "sha512-jTywjboN9aHxFlToqb0K0Zs9SbBoW4zRUlGzI2tYNxVYcEi/IPpn+Xi4ye5jTLvX2YeLuic/IvxNot+Q1jMoOw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",
@@ -3219,6 +3224,7 @@
       "integrity": "sha512-MfwFQ6SfwinsUVi0rNJm7rHZ31GyTcpVE5pgVA3hwFRb7COD4TzjUUwhGWKfO50+xdc2MQPuEBBJoqIMGt3JDw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@discoveryjs/json-ext": "^0.6.1",
         "@webpack-cli/configtest": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -13,17 +13,17 @@
     "test": "grunt test"
   },
   "dependencies": {
-    "@xmldom/xmldom": "^0.8.10",
-    "lodash": "^4.17.21"
+    "@xmldom/xmldom": "0.8.13",
+    "lodash": "4.18.1"
   },
   "devDependencies": {
-    "@babel/core": "^7.28.5",
-    "@babel/preset-env": "^7.28.5",
-    "babel-loader": "^10.0.0",
-    "webpack": "^5.104.0",
-    "webpack-cli": "^6.0.1",
-    "webpack-fix-default-import-plugin": "^1.0.3",
-    "webpack-node-externals": "^3.0.0"
+    "@babel/core": "7.28.5",
+    "@babel/preset-env": "7.28.5",
+    "babel-loader": "10.0.0",
+    "webpack": "5.105.4",
+    "webpack-cli": "6.0.1",
+    "webpack-fix-default-import-plugin": "1.0.3",
+    "webpack-node-externals": "3.0.0"
   },
   "license": "MIT"
 }


### PR DESCRIPTION
## Summary

- Remove `^` range specifiers from all 9 direct dependencies in `package.json`
- Pin to lockfile resolved versions (not range minimums): `@xmldom/xmldom` 0.8.13, `lodash` 4.18.1, `webpack` 5.105.4
- Add `.github/dependabot.yml` with `versioning-strategy: increase` for automated patch updates
- Supersedes open dependabot PR for @xmldom/xmldom 0.8.13

## Validation

- `npm install` — 241 packages, 0 vulnerabilities
- `npm run build` — webpack compiled successfully
- No packages with install scripts (postinstall audit clean)

## Test plan

- [x] `npm install` resolves cleanly
- [x] `npm audit` reports 0 vulnerabilities
- [x] `npm run build` (webpack) compiles successfully
- [ ] Verify dependabot opens PRs with pinned version bumps after merge

Part of KEW-11022 — NPM Dependency Pinning (Supply Chain Hardening)

🤖 Generated with [Claude Code](https://claude.com/claude-code)