### PR TITLE
INTERNAL: Dependabot Improvements & Supply Chain Hardening

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,3 +6,10 @@ updates:
     schedule:
       interval: "weekly"
     versioning-strategy: increase
+    groups:
+      npm-patch:
+        update-types:
+          - "patch"
+      npm-minor:
+        update-types:
+          - "minor"

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,2 @@
 save-exact=true
+min-release-age=1


### PR DESCRIPTION
Applies the same dependency-management patterns as kno2-delivery#86:

- **dependabot.yml**: group npm update PRs by patch and by minor version (majors stay individual).
- **.npmrc**: add `min-release-age=1` so npm will not install package versions less than 24h old (supply-chain hardening; requires npm >= 11.10.0).